### PR TITLE
Reuse cached lens samples and reduce memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 # wait for exec end of Aeta
 
+## Recent updates
+- `compute_A_eta` now reuses existing `lens_samples.csv` when available instead of recomputing lens samples.
+- The normalization table is accumulated per sample to reduce peak memory usage.
+
 # now care about the mmdist
 
 

--- a/compute_A_eta.py
+++ b/compute_A_eta.py
@@ -105,16 +105,58 @@ def build_eta_grid():
     return mu_DM_grid, sigma_DM_grid, beta_DM_grid
 
 
-def compute_A_eta(n_samples=10000, ms_points=15, m_lim=26.5):
-    samples = sample_lens_population(n_samples)
-    mu1, mu2 = compute_magnifications(
-        samples["logM_star"],
-        samples["logRe"],
-        samples["logMh"],
-        samples["beta"],
-        samples["zl"],
-        samples["zs"],
-    )
+def compute_A_eta(n_samples=10000, ms_points=15, m_lim=26.5, lens_file="lens_samples.csv"):
+    """Compute normalization grid A(eta).
+
+    If a cached lens sample file exists with the requested number of samples,
+    reuse it instead of regenerating the lens population and recomputing
+    magnifications.  The final A-table is accumulated per sample to avoid
+    holding large 4D arrays in memory.
+    """
+
+    lens_df = None
+    if os.path.exists(lens_file):
+        cached = pd.read_csv(lens_file)
+        if len(cached) == n_samples:
+            lens_df = cached
+            print(f"Loaded {n_samples} lens samples from {lens_file}.")
+
+    if lens_df is None:
+        samples = sample_lens_population(n_samples)
+        mu1, mu2 = compute_magnifications(
+            samples["logM_star"],
+            samples["logRe"],
+            samples["logMh"],
+            samples["beta"],
+            samples["zl"],
+            samples["zs"],
+        )
+        lens_df = pd.DataFrame(
+            {
+                "logM_star": samples["logM_star"],
+                "logRe": samples["logRe"],
+                "logMh": samples["logMh"],
+                "beta": samples["beta"],
+                "mu1": mu1,
+                "mu2": mu2,
+                "zl": np.full(n_samples, samples["zl"]),
+                "zs": np.full(n_samples, samples["zs"]),
+            }
+        )
+        lens_df.to_csv(lens_file, index=False)
+    else:
+        samples = {
+            "logM_star": lens_df["logM_star"].values,
+            "logRe": lens_df["logRe"].values,
+            "logMh": lens_df["logMh"].values,
+            "beta": lens_df["beta"].values,
+            "zl": lens_df.get("zl", pd.Series([0.3])).iloc[0],
+            "zs": lens_df.get("zs", pd.Series([2.0])).iloc[0],
+            "logMh_min": 11.0,
+            "logMh_max": 15.0,
+        }
+        mu1 = lens_df["mu1"].values
+        mu2 = lens_df["mu2"].values
 
     ms_grid = np.linspace(20.0, 30.0, ms_points)
     pdf_ms = ms_distribution(ms_grid)
@@ -125,37 +167,28 @@ def compute_A_eta(n_samples=10000, ms_points=15, m_lim=26.5):
     # correct for beta sampling (beta ~ 2*beta_uniform)
     w_static = w_ms / (2.0 * samples["beta"])
 
-    lens_df = pd.DataFrame(
-        {
-            "logM_star": samples["logM_star"],
-            "logRe": samples["logRe"],
-            "logMh": samples["logMh"],
-            "beta": samples["beta"],
-            "mu1": mu1,
-            "mu2": mu2,
-            "w_ms": w_ms,
-            "w_static": w_static,
-            "zl": np.full(n_samples, samples["zl"]),
-            "zs": np.full(n_samples, samples["zs"]),
-        }
-    )
-    lens_df.to_csv("lens_samples.csv", index=False)
+    lens_df["w_ms"] = w_ms
+    lens_df["w_static"] = w_static
+    lens_df.to_csv(lens_file, index=False)
 
     mu_DM_grid, sigma_DM_grid, beta_DM_grid = build_eta_grid()
 
-    logM_star = samples["logM_star"][:, None, None, None]
-    logMh = samples["logMh"][:, None, None, None]
-    w = w_static[:, None, None, None]
+    mu_grid = mu_DM_grid[:, None, None]
+    sigma_grid = sigma_DM_grid[None, :, None]
+    beta_grid = beta_DM_grid[None, None, :]
+    A_accum = np.zeros((mu_DM_grid.size, sigma_DM_grid.size, beta_DM_grid.size))
 
-    mu_grid = mu_DM_grid[None, :, None, None]
-    sigma_grid = sigma_DM_grid[None, None, :, None]
-    beta_grid = beta_DM_grid[None, None, None, :]
+    for logM_star_i, logMh_i, w_i in tqdm(
+        zip(samples["logM_star"], samples["logMh"], w_static),
+        total=n_samples,
+        desc="accumulating A",
+    ):
+        mean = mu_grid + beta_grid * (logM_star_i - 11.4)
+        p_Mh = norm.pdf(logMh_i, loc=mean, scale=sigma_grid)
+        A_accum += w_i * p_Mh
 
-    mean = mu_grid + beta_grid * (logM_star - 11.4)
-    p_Mh = norm.pdf(logMh, loc=mean, scale=sigma_grid)
-
-    Mh_range = samples["logMh_max"] - samples["logMh_min"]
-    A = Mh_range * np.sum(w * p_Mh, axis=0) / n_samples
+    Mh_range = samples.get("logMh_max", 15.0) - samples.get("logMh_min", 11.0)
+    A = Mh_range * A_accum / n_samples
 
     mu_flat, sigma_flat, beta_flat = np.meshgrid(
         mu_DM_grid, sigma_DM_grid, beta_DM_grid, indexing="ij"


### PR DESCRIPTION
## Summary
- Load existing `lens_samples.csv` when it matches the requested sample size to avoid expensive recomputation.
- Stream the normalization calculation sample-by-sample to reduce memory footprint.
- Document the new caching and memory improvements in the README.

## Testing
- `python -m py_compile compute_A_eta.py`
- `python - <<'PY'
from compute_A_eta import compute_A_eta
compute_A_eta(n_samples=10, ms_points=5, m_lim=24)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6893ae6c8308832d94f3f3d3e3ee5f7e